### PR TITLE
feat: Add isInstance flag to subtasks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -884,7 +884,8 @@ const handleMoveTodaySubtask = useCallback((subtaskId: string, direction: 'up' |
               order: task.order ?? index,
               subtasks: (task.subtasks || []).map((st: any, stIndex: number) => ({
                 ...st,
-                order: st.order ?? stIndex
+                order: st.order ?? stIndex,
+                isInstance: st.isInstance ?? false,
               }))
             }));
 
@@ -1022,6 +1023,7 @@ const handleMoveTodaySubtask = useCallback((subtaskId: string, direction: 'up' |
       subtasks: (task.subtasks || []).map((subtask, subtaskIndex) => ({
         ...subtask,
         order: subtask.order ?? subtaskIndex,
+        isInstance: subtask.isInstance ?? false,
       })),
     }));
     


### PR DESCRIPTION
Introduce an `isInstance` boolean flag to subtasks during data import and task duplication. This will help differentiate between original subtasks and duplicated instances in future functionality.