### PR TITLE
feat: Improve task description handling in 'Today' view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -709,6 +709,15 @@ const App: React.FC = () => {
     setTasks(prev => prev.map(t => t.id === taskId ? updatedTask : t));
 
   }, [tasks, isOnlineMode, supabase]);
+
+  const handleUpdateParentTaskDescription = useCallback(async (taskId: string, newDescription: string) => {
+    const taskToUpdate = tasks.find(t => t.id === taskId);
+    if (!taskToUpdate) return;
+    
+    const updatedTask = { ...taskToUpdate, description: newDescription };
+    // This will call the existing update logic (local + supabase)
+    await handleUpdateTask(updatedTask);
+  }, [tasks, handleUpdateTask]);
   
   const handleMoveTask = useCallback(async (taskId: string, direction: 'up' | 'down' | 'top' | 'bottom') => {
     
@@ -1505,7 +1514,8 @@ const handleMoveTodaySubtask = useCallback((subtaskId: string, direction: 'up' |
                                     item={{ 
                                       subtask: item.subtask, 
                                       parentTaskTitle: item.parentTask.title, 
-                                      parentTaskDescription: item.parentTask.description 
+                                      parentTaskDescription: item.parentTask.description,
+                                      parentTaskId: item.parentTask.id,
                                     }}
                                     onToggleComplete={() => handleToggleTodaySubtaskComplete(item.subtask.id, item.parentTask.id)}
                                     onRemove={() => handleUnsetSubtaskDueDate(item.subtask.id, item.parentTask.id)}
@@ -1516,6 +1526,7 @@ const handleMoveTodaySubtask = useCallback((subtaskId: string, direction: 'up' |
                                     onMoveSubtask={handleMoveTodaySubtask}
                                     subtaskIndex={index}
                                     totalSubtasks={incompleteTodaySubtasks.length}
+                                    onUpdateParentTaskDescription={handleUpdateParentTaskDescription}
                                 />
                             ))}
                         </div>
@@ -1530,7 +1541,8 @@ const handleMoveTodaySubtask = useCallback((subtaskId: string, direction: 'up' |
                                     item={{ 
                                       subtask: item.subtask, 
                                       parentTaskTitle: item.parentTask.title,
-                                      parentTaskDescription: item.parentTask.description
+                                      parentTaskDescription: item.parentTask.description,
+                                      parentTaskId: item.parentTask.id,
                                     }}
                                     onToggleComplete={() => handleToggleTodaySubtaskComplete(item.subtask.id, item.parentTask.id)}
                                     onRemove={() => handleUnsetSubtaskDueDate(item.subtask.id, item.parentTask.id)}
@@ -1541,6 +1553,7 @@ const handleMoveTodaySubtask = useCallback((subtaskId: string, direction: 'up' |
                                     onMoveSubtask={() => {}}
                                     subtaskIndex={index}
                                     totalSubtasks={completedTodaySubtasks.length}
+                                    onUpdateParentTaskDescription={handleUpdateParentTaskDescription}
                                 />
                             ))}
                         </div>

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -201,17 +201,10 @@ const TaskItem: React.FC<TaskItemProps> = ({ task, onDelete, onUpdate, onOpenSub
                         )}
                     </div>
                     {task.description && (
-                      <div className="mt-2">
-                        <button onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)} className="flex items-center text-xs text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 font-medium">
-                            {isDescriptionExpanded ? 'Nascondi Descrizione' : 'Mostra Descrizione'}
-                            {isDescriptionExpanded ? <ChevronUpIcon className="h-4 w-4 ml-1" /> : <ChevronDownIcon className="h-4 w-4 ml-1" />}
-                        </button>
-                        {isDescriptionExpanded && (
-                           <div className="mt-2 p-3 bg-gray-50 dark:bg-gray-900/50 rounded-md border border-gray-200 dark:border-gray-700 prose max-w-none text-sm sm:text-base">
-                             <ReactMarkdown remarkPlugins={[remarkGfm]}>{task.description}</ReactMarkdown>
-                           </div>
-                        )}
-                      </div>
+                      <button onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)} className="mt-2 flex items-center text-xs text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 font-medium">
+                          {isDescriptionExpanded ? 'Nascondi Descrizione' : 'Mostra Descrizione'}
+                          {isDescriptionExpanded ? <ChevronUpIcon className="h-4 w-4 ml-1" /> : <ChevronDownIcon className="h-4 w-4 ml-1" />}
+                      </button>
                     )}
                 </div>
             )}
@@ -278,6 +271,12 @@ const TaskItem: React.FC<TaskItemProps> = ({ task, onDelete, onUpdate, onOpenSub
             ) : null}
         </div>
       </div>
+      
+      {!isEditing && isDescriptionExpanded && task.description && (
+         <div className="mt-2 p-3 bg-gray-50 dark:bg-gray-900/50 rounded-md border border-gray-200 dark:border-gray-700 prose max-w-none text-sm sm:text-base">
+           <ReactMarkdown remarkPlugins={[remarkGfm]}>{task.description}</ReactMarkdown>
+         </div>
+      )}
 
        {task.snoozeUntil && !task.completed && onUnsnoozeTask && (
         <div className="mt-3 p-2 bg-yellow-100 dark:bg-yellow-900/50 rounded-md flex items-center justify-between">

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -27,7 +27,8 @@ import {
   Clock,
   LogOut,
   Archive,
-  AlarmClockOff
+  AlarmClockOff,
+  CalendarX2
 } from 'lucide-react';
 
 // Note: The original components had specific classNames.
@@ -86,3 +87,5 @@ export const LogOutIcon = (props: LucideProps) => <LogOut className="h-6 w-6" {.
 export const ArchiveIcon = (props: LucideProps) => <Archive className="h-6 w-6" {...props} />;
 
 export const SnoozeIcon = ({ className = "h-6 w-6", ...props }: LucideProps) => <AlarmClockOff className={className} {...props} />;
+
+export const CalendarX2Icon = (props: LucideProps) => <CalendarX2 className="h-5 w-5" {...props} />;


### PR DESCRIPTION
Introduces the ability to toggle the visibility of parent task descriptions within the 'Today' view. This change also refactors the description display logic in `TaskItem` to make it more reusable and lays the groundwork for potential inline editing of parent task descriptions in the future.

Additionally, a new `CalendarX2Icon` has been added to the icons library for future use.