### PR TITLE
feat: Correctly parse snoozeUntil dates

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -309,7 +309,7 @@ const App: React.FC = () => {
 
     let activeTasks = tasks.filter(task => 
       !task.completed &&
-      (!task.snoozeUntil || new Date(task.snoozeUntil) <= today)
+      (!task.snoozeUntil || new Date(task.snoozeUntil + 'T00:00:00') <= today)
     );
 
     if (selectedTags.length > 0) {
@@ -342,8 +342,8 @@ const App: React.FC = () => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     return tasks
-      .filter(task => task.snoozeUntil && new Date(task.snoozeUntil) > today && !task.completed)
-      .sort((a, b) => new Date(a.snoozeUntil!).getTime() - new Date(b.snoozeUntil!).getTime());
+      .filter(task => task.snoozeUntil && new Date(task.snoozeUntil + 'T00:00:00') > today && !task.completed)
+      .sort((a, b) => new Date(a.snoozeUntil! + 'T00:00:00').getTime() - new Date(b.snoozeUntil! + 'T00:00:00').getTime());
   }, [tasks]);
 
   const archivedTasks = useMemo(() => {


### PR DESCRIPTION
SnoozeUntil dates were not being parsed correctly, leading to tasks being displayed when they should have been snoozed. This commit adds 'T00:00:00' to ensure correct date parsing for the snoozeUntil field.