### PR TITLE
feat: Add `tasks` to useCallback dependencies

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -629,7 +629,7 @@ const App: React.FC = () => {
         }
         return task;
     }));
-  }, [isOnlineMode, supabase]);
+  }, [tasks, isOnlineMode, supabase]);
 
   const handleUnsnoozeTask = useCallback(async (taskId: string) => {
     if (isOnlineMode && supabase) {
@@ -646,7 +646,7 @@ const App: React.FC = () => {
           }
           return task;
       }));
-  }, [isOnlineMode, supabase]);
+  }, [tasks, isOnlineMode, supabase]);
 
   const handleSetSubtaskDueDate = useCallback(async (subtaskId: string, taskId: string, date: string) => {
     const task = tasks.find(t => t.id === taskId);


### PR DESCRIPTION
Adds `tasks` to the dependency arrays of `handleSnoozeTask` and `handleUnsnoozeTask` useCallback hooks. This ensures that these handlers correctly reflect the latest state of the `tasks` array when they are invoked, preventing stale closures.