### PR TITLE
feat: Add task loading indicators and logic

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,12 +20,13 @@ const App: React.FC = () => {
   } = useUI();
 
   const {
-    api, isOnlineMode, supabaseConfig, isLoading, statusMessage,
+    api, isOnlineMode, supabaseConfig, isLoading: isSyncLoading, statusMessage,
     setIsOnlineMode, handleSaveSupabaseConfig, handleMigrateToLocal, handleMigrateToOnline
   } = useAppSync(view, theme);
 
   const {
     allTasks, backlogTasks, snoozedTasks, archivedTasks, modalTask, draggedTask,
+    taskLoadingState, loadBacklogTasks, loadSnoozedTasks, loadArchivedTasks, loadAllTasks,
     handleAddTask, requestDeleteTask, handleUpdateTask, handleToggleTaskComplete,
     handleSnoozeTask, handleUnsnoozeTask, handleSetSubtaskDueDate, handleUpdateSubtaskText,
     handleMoveTask, handleOpenSubtaskModal, handleCloseModal,
@@ -56,6 +57,7 @@ const App: React.FC = () => {
                   onSnoozeTask={handleSnoozeTask} onUnsnoozeTask={handleUnsnoozeTask} onTagClick={(tag) => setSelectedTags(prev => prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag])}
                   onClearTags={() => setSelectedTags([])} onSetSortOption={setSortOption} onSetCompactView={setCompactView}
                   onUpdateSubtaskText={handleUpdateSubtaskText} onSetSubtaskDueDate={handleSetSubtaskDueDate}
+                  loadTasks={loadBacklogTasks} isLoading={taskLoadingState.backlog}
               />;
           case 'today':
               return <TodayPage
@@ -67,21 +69,28 @@ const App: React.FC = () => {
                       if(task) handleUpdateTask({ ...task, description: newDescription });
                   }} 
                   onUpdateSubtaskText={handleUpdateSubtaskText}
+                  loadTasks={loadAllTasks} isLoading={taskLoadingState.backlog || taskLoadingState.snoozed || taskLoadingState.archive}
               />;
           case 'snoozed':
               return <SnoozedPage 
                   snoozedTasks={snoozedTasks} allTags={allTags} onDeleteTask={requestDeleteTask} onUpdateTask={handleUpdateTask}
                   onOpenSubtaskModal={handleOpenSubtaskModal} onToggleTaskComplete={handleToggleTaskComplete} onSnoozeTask={handleSnoozeTask}
                   onUnsnoozeTask={handleUnsnoozeTask} onUpdateSubtaskText={handleUpdateSubtaskText} onSetSubtaskDueDate={handleSetSubtaskDueDate}
+                  loadTasks={loadSnoozedTasks} isLoading={taskLoadingState.snoozed}
               />;
           case 'archive':
               return <ArchivePage
                   archivedTasks={archivedTasks} allTags={allTags} onDeleteTask={requestDeleteTask} onUpdateTask={handleUpdateTask}
                   onOpenSubtaskModal={handleOpenSubtaskModal} onToggleTaskComplete={handleToggleTaskComplete}
                   onUpdateSubtaskText={handleUpdateSubtaskText} onSetSubtaskDueDate={handleSetSubtaskDueDate}
+                  loadTasks={loadArchivedTasks} isLoading={taskLoadingState.archive}
               />;
           case 'stats':
-              return <StatsPage tasks={allTasks} />;
+              return <StatsPage 
+                  tasks={allTasks} 
+                  loadTasks={loadAllTasks} 
+                  isLoading={taskLoadingState.backlog || taskLoadingState.snoozed || taskLoadingState.archive} 
+              />;
           case 'settings':
               return <SettingsPage
                   currentConfig={supabaseConfig} onSave={handleSaveSupabaseConfig} isOnlineMode={isOnlineMode}
@@ -131,8 +140,8 @@ const App: React.FC = () => {
           </div>
         )}
 
-        {isLoading ? (
-          <div className="flex items-center justify-center my-4"><SpinnerIcon /> <span className="ml-2">Loading data...</span></div>
+        {isSyncLoading ? (
+          <div className="flex items-center justify-center my-4"><SpinnerIcon /> <span className="ml-2">Migrating data...</span></div>
         ) : (
           renderView()
         )}

--- a/pages/ArchivePage.tsx
+++ b/pages/ArchivePage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Task } from '../types';
 import TaskItem from '../components/TaskItem';
+import { SpinnerIcon } from '../components/icons';
 
 interface ArchivePageProps {
   archivedTasks: Task[];
@@ -11,39 +12,56 @@ interface ArchivePageProps {
   onToggleTaskComplete: (taskId: string) => void;
   onUpdateSubtaskText: (taskId: string, subtaskId: string, newText: string) => void;
   onSetSubtaskDueDate: (subtaskId: string, taskId: string, date: string) => void;
+  loadTasks: () => void;
+  isLoading: boolean;
 }
 
 const ArchivePage: React.FC<ArchivePageProps> = ({
   archivedTasks, allTags, onDeleteTask, onUpdateTask, onOpenSubtaskModal,
-  onToggleTaskComplete, onUpdateSubtaskText, onSetSubtaskDueDate
+  onToggleTaskComplete, onUpdateSubtaskText, onSetSubtaskDueDate,
+  loadTasks, isLoading
 }) => {
+  useEffect(() => {
+    loadTasks();
+  }, [loadTasks]);
+
+  const sortedArchivedTasks = [...archivedTasks].sort((a,b) => (b.completionDate || '').localeCompare(a.completionDate || ''));
+
   return (
     <div className="animate-fade-in-down">
       <h2 className="text-xl sm:text-2xl font-bold text-gray-700 dark:text-gray-300 mb-4">Archived Tasks</h2>
-      {archivedTasks.map((task) => (
-        <TaskItem
-          key={task.id}
-          task={task}
-          onDelete={onDeleteTask}
-          onUpdate={onUpdateTask}
-          onOpenSubtaskModal={onOpenSubtaskModal}
-          onDragStart={() => {}}
-          onDragOver={() => {}}
-          onDrop={() => {}}
-          isDragging={false}
-          onSetSubtaskDueDate={onSetSubtaskDueDate}
-          onToggleTaskComplete={onToggleTaskComplete}
-          allTags={allTags}
-          isCompactView={false}
-          onMoveTask={() => {}}
-          taskIndex={-1}
-          totalTasks={-1}
-          onSnoozeTask={() => {}}
-          isDraggable={false}
-          onUpdateSubtaskText={onUpdateSubtaskText}
-        />
-      ))}
-      {archivedTasks.length === 0 && <p className="text-center py-10 text-gray-500">No completed tasks yet.</p>}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-10">
+            <SpinnerIcon />
+            <span className="ml-2">Loading archive...</span>
+        </div>
+      ) : sortedArchivedTasks.length > 0 ? (
+        sortedArchivedTasks.map((task) => (
+          <TaskItem
+            key={task.id}
+            task={task}
+            onDelete={onDeleteTask}
+            onUpdate={onUpdateTask}
+            onOpenSubtaskModal={onOpenSubtaskModal}
+            onDragStart={() => {}}
+            onDragOver={() => {}}
+            onDrop={() => {}}
+            isDragging={false}
+            onSetSubtaskDueDate={onSetSubtaskDueDate}
+            onToggleTaskComplete={onToggleTaskComplete}
+            allTags={allTags}
+            isCompactView={false}
+            onMoveTask={() => {}}
+            taskIndex={-1}
+            totalTasks={-1}
+            onSnoozeTask={() => {}}
+            isDraggable={false}
+            onUpdateSubtaskText={onUpdateSubtaskText}
+          />
+        ))
+      ) : (
+        <p className="text-center py-10 text-gray-500">No completed tasks yet.</p>
+      )}
     </div>
   );
 };

--- a/pages/BacklogPage.tsx
+++ b/pages/BacklogPage.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { Task } from '../types';
 // FIX: The SortOption type is exported from useUI.ts, not App.tsx.
 import { SortOption } from '../hooks/useUI';
 import TaskItem from '../components/TaskItem';
-import { PlusIcon, ArrowsPointingInIcon, ArrowsPointingOutIcon } from '../components/icons';
+import { PlusIcon, ArrowsPointingInIcon, ArrowsPointingOutIcon, SpinnerIcon } from '../components/icons';
 import MarkdownInput from '../components/MarkdownInput';
 
 interface BacklogPageProps {
@@ -30,6 +30,8 @@ interface BacklogPageProps {
   onSetCompactView: (isCompact: boolean) => void;
   onUpdateSubtaskText: (taskId: string, subtaskId: string, newText: string) => void;
   onSetSubtaskDueDate: (subtaskId: string, taskId: string, date: string) => void;
+  loadTasks: () => void;
+  isLoading: boolean;
 }
 
 const extractTags = (text: string): string[] => {
@@ -64,11 +66,16 @@ const BacklogPage: React.FC<BacklogPageProps> = ({
   backlogTasks, draggedTask, allTags, selectedTags, isCompactView, sortOption,
   onAddTask, onDeleteTask, onUpdateTask, onOpenSubtaskModal, onDragStart, onDragOver, onDrop,
   onToggleTaskComplete, onMoveTask, onSnoozeTask, onUnsnoozeTask, onTagClick, onClearTags,
-  onSetSortOption, onSetCompactView, onUpdateSubtaskText, onSetSubtaskDueDate
+  onSetSortOption, onSetCompactView, onUpdateSubtaskText, onSetSubtaskDueDate,
+  loadTasks, isLoading
 }) => {
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [newTaskDescription, setNewTaskDescription] = useState('');
   const [isFormVisible, setIsFormVisible] = useState(false);
+
+  useEffect(() => {
+    loadTasks();
+  }, [loadTasks]);
 
   const handleAddTagToDescription = useCallback((tag: string, setter: React.Dispatch<React.SetStateAction<string>>) => {
     setter(prev => `${prev.trim()} ${tag}`.trim());
@@ -199,34 +206,40 @@ const BacklogPage: React.FC<BacklogPageProps> = ({
       </div>
 
       <div>
-        {sortedAndFilteredTasks.map((task, index) => (
-          <TaskItem
-            key={task.id}
-            task={task}
-            onDelete={onDeleteTask}
-            onUpdate={onUpdateTask}
-            onOpenSubtaskModal={onOpenSubtaskModal}
-            onDragStart={onDragStart}
-            onDragOver={onDragOver}
-            onDrop={onDrop}
-            isDragging={draggedTask?.id === task.id}
-            onSetSubtaskDueDate={onSetSubtaskDueDate}
-            onToggleTaskComplete={onToggleTaskComplete}
-            allTags={allTags}
-            isCompactView={isCompactView}
-            onMoveTask={onMoveTask}
-            taskIndex={index}
-            totalTasks={sortedAndFilteredTasks.length}
-            onSnoozeTask={onSnoozeTask}
-            onUnsnoozeTask={onUnsnoozeTask}
-            isDraggable={sortOption === 'manual'}
-            onUpdateSubtaskText={onUpdateSubtaskText}
-          />
-        ))}
-        {sortedAndFilteredTasks.length === 0 && (
-          <div className="text-center py-10">
-            <p className="text-gray-500">No active tasks found. Time to add some!</p>
-          </div>
+        {isLoading ? (
+            <div className="flex items-center justify-center py-10">
+                <SpinnerIcon />
+                <span className="ml-2">Loading tasks...</span>
+            </div>
+        ) : sortedAndFilteredTasks.length > 0 ? (
+            sortedAndFilteredTasks.map((task, index) => (
+                <TaskItem
+                    key={task.id}
+                    task={task}
+                    onDelete={onDeleteTask}
+                    onUpdate={onUpdateTask}
+                    onOpenSubtaskModal={onOpenSubtaskModal}
+                    onDragStart={onDragStart}
+                    onDragOver={onDragOver}
+                    onDrop={onDrop}
+                    isDragging={draggedTask?.id === task.id}
+                    onSetSubtaskDueDate={onSetSubtaskDueDate}
+                    onToggleTaskComplete={onToggleTaskComplete}
+                    allTags={allTags}
+                    isCompactView={isCompactView}
+                    onMoveTask={onMoveTask}
+                    taskIndex={index}
+                    totalTasks={sortedAndFilteredTasks.length}
+                    onSnoozeTask={onSnoozeTask}
+                    onUnsnoozeTask={onUnsnoozeTask}
+                    isDraggable={sortOption === 'manual'}
+                    onUpdateSubtaskText={onUpdateSubtaskText}
+                />
+            ))
+        ) : (
+            <div className="text-center py-10">
+                <p className="text-gray-500">No active tasks found. Time to add some!</p>
+            </div>
         )}
       </div>
     </>

--- a/pages/SnoozedPage.tsx
+++ b/pages/SnoozedPage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Task } from '../types';
 import TaskItem from '../components/TaskItem';
+import { SpinnerIcon } from '../components/icons';
 
 interface SnoozedPageProps {
   snoozedTasks: Task[];
@@ -13,41 +14,57 @@ interface SnoozedPageProps {
   onUnsnoozeTask: (taskId: string) => void;
   onUpdateSubtaskText: (taskId: string, subtaskId: string, newText: string) => void;
   onSetSubtaskDueDate: (subtaskId: string, taskId: string, date: string) => void;
+  loadTasks: () => void;
+  isLoading: boolean;
 }
 
 const SnoozedPage: React.FC<SnoozedPageProps> = ({
   snoozedTasks, allTags, onDeleteTask, onUpdateTask, onOpenSubtaskModal,
   onToggleTaskComplete, onSnoozeTask, onUnsnoozeTask, onUpdateSubtaskText,
-  onSetSubtaskDueDate
+  onSetSubtaskDueDate, loadTasks, isLoading
 }) => {
+  useEffect(() => {
+    loadTasks();
+  }, [loadTasks]);
+  
+  const sortedSnoozedTasks = [...snoozedTasks].sort((a, b) => (a.snoozeUntil || '').localeCompare(b.snoozeUntil || ''));
+
   return (
     <div className="animate-fade-in-down">
       <h2 className="text-xl sm:text-2xl font-bold text-gray-700 dark:text-gray-300 mb-4">Snoozed Tasks</h2>
-      {snoozedTasks.map((task) => (
-        <TaskItem
-          key={task.id}
-          task={task}
-          onDelete={onDeleteTask}
-          onUpdate={onUpdateTask}
-          onOpenSubtaskModal={onOpenSubtaskModal}
-          onDragStart={() => {}}
-          onDragOver={() => {}}
-          onDrop={() => {}}
-          isDragging={false}
-          onSetSubtaskDueDate={onSetSubtaskDueDate}
-          onToggleTaskComplete={onToggleTaskComplete}
-          allTags={allTags}
-          isCompactView={false}
-          onMoveTask={() => {}}
-          taskIndex={-1}
-          totalTasks={-1}
-          onSnoozeTask={onSnoozeTask}
-          onUnsnoozeTask={onUnsnoozeTask}
-          isDraggable={false}
-          onUpdateSubtaskText={onUpdateSubtaskText}
-        />
-      ))}
-      {snoozedTasks.length === 0 && <p className="text-center py-10 text-gray-500">No snoozed tasks.</p>}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-10">
+          <SpinnerIcon />
+          <span className="ml-2">Loading snoozed tasks...</span>
+        </div>
+      ) : sortedSnoozedTasks.length > 0 ? (
+        sortedSnoozedTasks.map((task) => (
+          <TaskItem
+            key={task.id}
+            task={task}
+            onDelete={onDeleteTask}
+            onUpdate={onUpdateTask}
+            onOpenSubtaskModal={onOpenSubtaskModal}
+            onDragStart={() => {}}
+            onDragOver={() => {}}
+            onDrop={() => {}}
+            isDragging={false}
+            onSetSubtaskDueDate={onSetSubtaskDueDate}
+            onToggleTaskComplete={onToggleTaskComplete}
+            allTags={allTags}
+            isCompactView={false}
+            onMoveTask={() => {}}
+            taskIndex={-1}
+            totalTasks={-1}
+            onSnoozeTask={onSnoozeTask}
+            onUnsnoozeTask={onUnsnoozeTask}
+            isDraggable={false}
+            onUpdateSubtaskText={onUpdateSubtaskText}
+          />
+        ))
+      ) : (
+        <p className="text-center py-10 text-gray-500">No snoozed tasks.</p>
+      )}
     </div>
   );
 };

--- a/pages/StatsPage.tsx
+++ b/pages/StatsPage.tsx
@@ -1,8 +1,11 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { Task } from '../types';
+import { SpinnerIcon } from '../components/icons';
 
 interface StatsPageProps {
   tasks: Task[];
+  loadTasks: () => void;
+  isLoading: boolean;
 }
 
 const StatsCard = ({ title, value, colorClass = 'text-indigo-500 dark:text-indigo-400' }: { title: string, value: number | string, colorClass?: string }) => (
@@ -20,7 +23,11 @@ const getTodayDateString = () => {
     return `${yyyy}-${mm}-${dd}`;
 };
 
-const StatsPage: React.FC<StatsPageProps> = ({ tasks }) => {
+const StatsPage: React.FC<StatsPageProps> = ({ tasks, loadTasks, isLoading }) => {
+  useEffect(() => {
+    loadTasks();
+  }, [loadTasks]);
+
   const stats = useMemo(() => {
     const todayString = getTodayDateString();
     const getDateKey = (date: Date) => date.toISOString().split('T')[0];
@@ -73,6 +80,15 @@ const StatsPage: React.FC<StatsPageProps> = ({ tasks }) => {
   }, [tasks]);
 
   const maxWeeklyCompletion = Math.max(...Object.values(stats.weeklyCompletion), 1);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <SpinnerIcon />
+        <span className="ml-2">Loading stats...</span>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-8 animate-fade-in-down">

--- a/pages/TodayPage.tsx
+++ b/pages/TodayPage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Subtask, Task } from '../types';
 import TodaySubtaskItem from '../components/TodaySubtaskItem';
+import { SpinnerIcon } from '../components/icons';
 
 type TodayItem = { subtask: Subtask, parentTask: Task };
 
@@ -16,13 +17,29 @@ interface TodayPageProps {
   onMoveSubtask: (subtaskId: string, direction: 'up' | 'down' | 'top' | 'bottom') => void;
   onUpdateParentTaskDescription: (taskId: string, newDescription: string) => void;
   onUpdateSubtaskText: (taskId: string, subtaskId: string, newText: string) => void;
+  loadTasks: () => void;
+  isLoading: boolean;
 }
 
 const TodayPage: React.FC<TodayPageProps> = ({
   incompleteTodaySubtasks, completedTodaySubtasks, draggedTodayItem,
   onToggleComplete, onRemoveDueDate, onDragStart, onDragOver, onDrop,
-  onMoveSubtask, onUpdateParentTaskDescription, onUpdateSubtaskText
+  onMoveSubtask, onUpdateParentTaskDescription, onUpdateSubtaskText,
+  loadTasks, isLoading
 }) => {
+  useEffect(() => {
+    loadTasks();
+  }, [loadTasks]);
+  
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <SpinnerIcon />
+        <span className="ml-2">Loading today's tasks...</span>
+      </div>
+    );
+  }
+
   return (
     <div className="animate-fade-in-down">
       <h2 className="text-xl sm:text-2xl font-bold text-gray-700 dark:text-gray-300 mb-4">Today's Focus</h2>


### PR DESCRIPTION
Introduces a loading state for task lists across different pages (Backlog, Today, Snoozed, Archive). This provides visual feedback to the user while tasks are being fetched or synchronized.

The changes include:
- Renaming `isLoading` from `useAppSync` to `isSyncLoading` for clarity.
- Introducing `taskLoadingState` in `useTasks` to manage individual task loading.
- Adding `loadTasks` functions to pages that display task lists.
- Implementing `useEffect` hooks in these pages to call `loadTasks` on mount.
- Displaying a `SpinnerIcon` and loading message when tasks are loading.
- Passing `loadTasks` and `isLoading` props down to relevant components.