### PR TITLE
feat: Improve loading state and API readiness

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,7 +20,8 @@ const App: React.FC = () => {
   } = useUI();
 
   const {
-    api, isOnlineMode, supabaseConfig, isLoading: isSyncLoading, statusMessage,
+    // FIX: Destructure 'isLoading' from useAppSync and alias it to 'isSyncLoading' to resolve the error, as 'isSyncLoading' does not exist on the return type.
+    api, isOnlineMode, supabaseConfig, isLoading: isSyncLoading, isSessionLoading, statusMessage,
     setIsOnlineMode, handleSaveSupabaseConfig, handleMigrateToLocal, handleMigrateToOnline
   } = useAppSync(view, theme);
 
@@ -101,6 +102,8 @@ const App: React.FC = () => {
       }
   };
 
+  const isLoading = isSyncLoading || (isOnlineMode && isSessionLoading);
+
   return (
     <div className={`min-h-screen ${theme} bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-white`}>
       {modalTask && <SubtaskModal task={modalTask} onClose={handleCloseModal} onUpdateTask={handleUpdateTask} onSetSubtaskDueDate={handleSetSubtaskDueDate} />}
@@ -140,8 +143,13 @@ const App: React.FC = () => {
           </div>
         )}
 
-        {isSyncLoading ? (
-          <div className="flex items-center justify-center my-4"><SpinnerIcon /> <span className="ml-2">Migrating data...</span></div>
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center my-10">
+            <SpinnerIcon className="h-10 w-10 text-indigo-500" /> 
+            <span className="ml-2 mt-4 text-lg font-medium text-gray-600 dark:text-gray-300">
+              {isSyncLoading ? 'Migrating data...' : 'Connecting to online service...'}
+            </span>
+          </div>
         ) : (
           renderView()
         )}

--- a/services/taskService.ts
+++ b/services/taskService.ts
@@ -250,15 +250,22 @@ const createSupabaseApi = (supabase: SupabaseClient, session: Session): TaskApi 
  * @param isOnlineMode - Flag to determine if the app is in online or local mode.
  * @param supabase - The Supabase client instance, required for online mode.
  * @param session - The active Supabase session, required for online mode.
- * @returns An implementation of the TaskApi.
+ * @returns An implementation of the TaskApi, or null if the API is not ready.
  */
 export const createTaskService = (
     isOnlineMode: boolean,
     supabase: SupabaseClient | null,
     session: Session | null
-): TaskApi => {
-    if (isOnlineMode && supabase && session) {
+): TaskApi | null => {
+    if (isOnlineMode) {
+      if (supabase && session) {
+        // Online mode is fully ready.
         return createSupabaseApi(supabase, session);
+      }
+      // Online mode is selected, but the session is not yet available.
+      // Return null to indicate the API is not ready to be used.
+      return null;
     }
+    // Offline mode.
     return localApi;
 };


### PR DESCRIPTION
Introduces a more robust loading state to the application by differentiating between general sync loading and specific session loading for online mode. The `createTaskService` function now returns `null` if online mode is selected but the Supabase session is not yet available, indicating the API is not ready.

The `useTasks` hook is updated to handle the `TaskApi | null` return type, resetting task data when the API becomes available or changes. This prevents displaying stale data and ensures proper fetching from the correct data source.